### PR TITLE
Refactor/groups

### DIFF
--- a/Sudoku.py
+++ b/Sudoku.py
@@ -78,10 +78,10 @@ class Sudoku():
         self.groups['diagonal 1'] = diag_top_right_to_bottom_left
 
     def create_hyper_boxes(self):
-        self.groups['box 1'] = [(i, j) for i in [1, 2, 3] for j in [1, 2, 3]]
-        self.groups['box 2'] = [(i, j) for i in [1, 2, 3] for j in [5, 6, 7]]
-        self.groups['box 3'] = [(i, j) for i in [5, 6, 7] for j in [1, 2, 3]]
-        self.groups['box 4'] = [(i, j) for i in [5, 6, 7] for j in [5, 6, 7]]
+        self.groups['hyper-box (1,1)'] = [(i, j) for i in [1, 2, 3] for j in [1, 2, 3]]
+        self.groups['hyper-box (1,5)'] = [(i, j) for i in [1, 2, 3] for j in [5, 6, 7]]
+        self.groups['hyper-box (5,1)'] = [(i, j) for i in [5, 6, 7] for j in [1, 2, 3]]
+        self.groups['hyper-box (5,5)'] = [(i, j) for i in [5, 6, 7] for j in [5, 6, 7]]
 
     def create_cross(self):
         cross = {

--- a/Sudoku.py
+++ b/Sudoku.py
@@ -38,6 +38,7 @@ class Sudoku():
                         cell_memberships.append(g)
                 row.append(cell_memberships)
             self.memberships.append(row)
+        # create a grid of viable candidates for each position
         candidates = []
         for i in range(n):
             row = []
@@ -89,8 +90,6 @@ class Sudoku():
             (4, 2), (4, 3), (4, 5), (4, 6)
         }
         self.groups['cross'] = cross
-        # create a grid of viable candidates for each position
-
 
     def get_values(self, group: str):
         values = [self.grid[i][j] for (i, j) in self.groups[group]]

--- a/Sudoku.py
+++ b/Sudoku.py
@@ -28,16 +28,16 @@ class Sudoku():
         if is_cross_Sudoku:
             self.create_cross()
         # create reverse maps to groups
-        self.cells = []
+        self.memberships = []
         for i in range(n):
             row = []
             for j in range(n):
-                cell = []
+                cell_memberships = []
                 for g in self.groups.values():
                     if (i, j) in g:
-                        cell.append(g)
-                row.append(cell)
-            self.cells.append(row)
+                        cell_memberships.append(g)
+                row.append(cell_memberships)
+            self.memberships.append(row)
         candidates = []
         for i in range(n):
             row = []
@@ -103,7 +103,7 @@ class Sudoku():
         return inds_box
 
     def get_neighbour_inds(self, r: int, c: int, flatten=False):
-        neighbours = self.cells[r][c]
+        neighbours = self.memberships[r][c]
         if flatten:
             return list(set().union(*neighbours))
         return neighbours
@@ -111,7 +111,7 @@ class Sudoku():
     def find_options(self, r: int, c: int) -> Set:
         nums = set(range(1, SIZE + 1))
         used = set()
-        for group in self.cells[r][c]:
+        for group in self.memberships[r][c]:
             used |= set([self.grid[i][j] for (i, j) in group])
         valid = nums.difference(used)
         return valid

--- a/test_Sudoku.py
+++ b/test_Sudoku.py
@@ -53,14 +53,14 @@ class SudokuTest(unittest.TestCase):
                  [8, 2, 7, 0, 0, 0, 0, 0, 0],
                  [9, 1, 8, 0, 0, 0, 0, 0, 0]]
         s = Sudoku(grid)
-        self.assertEqual(s.get_col(0), [1, 2, 3, 4, 5, 6, 7, 8, 9])
-        self.assertTrue(s.no_duplicates(s.get_col(0)))
-        self.assertEqual(s.get_col(1), [9, 8, 7, 6, 5, 4, 3, 2, 1])
-        self.assertTrue(s.no_duplicates(s.get_col(1)))
-        self.assertEqual(s.get_col(3), [4, 0, 0, 0, 0, 0, 0, 0, 0])
-        self.assertTrue(s.no_duplicates(s.get_col(3)))
-        self.assertEqual(s.get_col(2), [3, 1, 2, 3, 4, 5, 6, 7, 8])
-        self.assertFalse(s.no_duplicates(s.get_col(2)))
+        self.assertEqual(s.get_values('column 0'), [1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertTrue(s.no_duplicates(s.get_values('column 0')))
+        self.assertEqual(s.get_values('column 1'), [9, 8, 7, 6, 5, 4, 3, 2, 1])
+        self.assertTrue(s.no_duplicates(s.get_values('column 1')))
+        self.assertEqual(s.get_values('column 3'), [4, 0, 0, 0, 0, 0, 0, 0, 0])
+        self.assertTrue(s.no_duplicates(s.get_values('column 3')))
+        self.assertEqual(s.get_values('column 2'), [3, 1, 2, 3, 4, 5, 6, 7, 8])
+        self.assertFalse(s.no_duplicates(s.get_values('column 2')))
 
     
     def check_box_test(self):
@@ -74,18 +74,13 @@ class SudokuTest(unittest.TestCase):
                  [0, 0, 0, 0, 0, 0, 0, 0, 0],
                  [0, 0, 0, 0, 0, 0, 0, 0, 0]]
         s = Sudoku(grid)
-        # different indices for the upper left box:
         box = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        self.assertEqual(s.get_box(0,0), box)
-        self.assertEqual(s.get_box(1,2), box)
-        self.assertEqual(s.get_box(2,2), box)
-        self.assertTrue(s.no_duplicates(s.get_box(0, 0)))
+        self.assertEqual(s.get_values('box (0,0)'), box)
+        self.assertTrue(s.no_duplicates(s.get_values('box (0,0)')))
         # different indices for the middle box:
         box = [1, 2, 2, 4, 5, 6, 7, 8, 8]
-        self.assertEqual(s.get_box(4,4), box)
-        self.assertEqual(s.get_box(3,3), box)
-        self.assertEqual(s.get_box(3,5), box)
-        self.assertFalse(s.no_duplicates(s.get_box(4, 4)))
+        self.assertEqual(s.get_values('box (3,3)'), box)
+        self.assertFalse(s.no_duplicates(s.get_values('box (3,3)')))
 
     
     def find_options_test(self):
@@ -139,7 +134,7 @@ class SudokuTest(unittest.TestCase):
         inds = [(7, j) for j in range(9)] # uniques: 8 at (7, 1)  and 6 at (7, 6)
         #self.assertEqual(s.get_unique(inds), [([(7, 6)], [6]), ([(7, 1)], [8])] ) #[(6, (7, 6)), (8, (7, 1))])
         self.assertEqual(s.get_unique(inds, type=[1]), [([(7, 6)], [6]), ([(7, 1)], [8])] )
-        inds = s.get_box_inds(5, 6)  # middle right box. unique 8 at (5,6)
+        inds = s.groups['box (3,6)']  # middle right box. unique 8 at (5,6)
         #self.assertEqual(s.get_unique(inds), [([(5, 6)], [8])])
         self.assertEqual(s.get_unique(inds, type=[1]), [([(5, 6)], [8])] )
         # test erase function


### PR DESCRIPTION
Consolidate all types of indices (rows, cols, boxes, hyper-boxes, diagonals) into a single group type. Add extra memberships array so that checking groups is still `O(1)` instead of `O(num_groups)`. 

This code is more generic and easier to extend than the base code. However this comes at the cost of understandability. 